### PR TITLE
Get rid of finger which is outdated

### DIFF
--- a/pkg/R/utilities.R
+++ b/pkg/R/utilities.R
@@ -4057,16 +4057,9 @@ getUserName <- function(){
     if (name == "unknown") name <- "Your Name"
     return(name)
   } else {
-    name <- try(system("finger $(whoami)", intern=TRUE, ignore.stderr=TRUE),
-                silent=TRUE)
-    if (!inherits(name, "try-error")){
-      name <- name[grepl("^Login:", name)]
-      return(sub("^.*Name: ", "", name))
-    } else {
-      name <- Sys.info()["user"]
-      if (name == "unknown") name <- "Your Name"
-      return(name)
-    }
+        name <- Sys.info()["user"]
+        if (length(name) == 0 || is.na(name) || name == "unknown") name <- "Your Name"
+        return(name)
   }
 }
 


### PR DESCRIPTION
Simply use Sys.info()["user"]

In many environments we run, hpc clusters with single or multi domains, finger is present but not implemented or filtered out...